### PR TITLE
Fix default `FileDirectory` in which the prepare script will run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Fix default FileDirectory in which the prepare script will run

--- a/prepareImage.st
+++ b/prepareImage.st
@@ -23,8 +23,9 @@
 		FileStream readOnlyFileNamed: postpareScriptPath do: [:stream | stream contents]].
 	
 	prepareScriptPath ifNotEmpty: [
-		FileDirectory setDefaultDirectory: (FileDirectory dirPathFor: prepareScriptPath).
-		FileStream readOnlyFileNamed: prepareScriptPath do: [:stream | stream fileIn]].
+		Smalltalk globals at: #CIPrepareImageDirectory put: (FileDirectory forFileName: prepareScriptPath).
+		FileStream readOnlyFileNamed: prepareScriptPath do: [:stream | stream fileIn].
+		Smalltalk globals removeKey: #CIPrepareImageDirectory].
 ] value.
 
 Smalltalk snapshot: true andQuitWithExitCode: 0.


### PR DESCRIPTION
Don't manipulate `FileDirectory default` any longer. Instead, provide the directory of the script via `Smalltalk global at: #CIPrepareImageDirectory`.