### PR TITLE
Workaround: Port missing `squeak.sh` features from linux-only variant

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
           prepare-script: test/prepare.st
           postpare-script: test/postpare.st
       - run: test/extract.sh "${{ steps.create-image.outputs.bundle-path }}"
-      - run: src/prepare_script.sh output/image/squeak.sh
       - run: output/image/squeak.sh "$(realpath test/test.st)"
         env:
-          VM_OPTION: "-headless"  # WORKAROUND: This should be passable directly to squeak.sh. See https://github.com/squeak-smalltalk/squeak-app/pull/17#issuecomment-876753284.
+          VMOPTIONS: "-headless"  # WORKAROUND: This should be passable directly to squeak.sh. See https://github.com/squeak-smalltalk/squeak-app/pull/17#issuecomment-876753284.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,5 @@ jobs:
       - run: test/extract.sh "${{ steps.create-image.outputs.bundle-path }}"
       - run: src/prepare_script.sh output/image/squeak.sh
       - run: output/image/squeak.sh "$(realpath test/test.st)"
+        env:
+          VM_OPTION: "-headless"  # WORKAROUND: This should be passable directly to squeak.sh. See https://github.com/squeak-smalltalk/squeak-app/pull/17#issuecomment-876753284.

--- a/src/create_image.sh
+++ b/src/create_image.sh
@@ -31,6 +31,10 @@ cd allInOne
 "$script_dir/prepare_script.sh" squeak.sh
 
 # Prepare image
+if [[ "$CI" == true ]]; then
+    VMOPTIONS="-headless"
+fi
+export VMOPTIONS
 ./squeak.sh "$fileinScript" "$prepareScript" "$postpareScript"
 
 # Clean up caches
@@ -40,5 +44,4 @@ rm -rf ./**/{{package,github}-cache/,\#tmp\#*}
 # Write changes back to zip
 zip \
     -u -r \
-    "../$buildAio" . \
-    -x squeak.sh  # See HACK above
+    "../$buildAio" .

--- a/src/prepare_script.sh
+++ b/src/prepare_script.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
-# HACK: Modify squeak.sh because arguments are currently not available for the All-in-One bundles
+# HACK: Modify squeak.sh because it currently misses several features that are not available for the All-in-One bundles.
 # See: https://github.com/squeak-smalltalk/squeak-app/pull/17#issuecomment-876753284
-sed -i '$s/$/ "$@"/' "$1"
-
-if [[ "$CI" == true ]]; then
-    # Add -headless flag to the VM configuration
-    # shellcheck disable=SC2016
-    sed -i 's/\(exec "${VM}"\)\( "${IMAGE}"\)/\1 -headless\2/' "$1"
-fi
+# Ported features:
+# - ${VMOPTIONS}
+# - detect_sound()
+# - "$@"
+# shellcheck disable=SC1004
+# shellcheck disable=SC2016
+sed -i 's!\(exec\)\( "${VM}"\)\( "${IMAGE}"\)!\
+detect_sound() {\
+    if pulseaudio --check 2>/dev/null ; then\
+        if "${VM}" --help 2>/dev/null | grep -q vm-sound-pulse ; then\
+	    VMOPTIONS="${VMOPTIONS} -vm-sound-pulse"\
+        else\
+            VMOPTIONS="${VMOPTIONS} -vm-sound-oss"\
+            if padsp true 2>/dev/null; then\
+                SOUNDSERVER=padsp\
+            fi\
+        fi\
+    fi\
+}\
+detect_sound\
+\
+\1 ${SOUNDSERVER}\2 ${VMOPTIONS}\3 "$@"!' "$1"


### PR DESCRIPTION
See https://github.com/squeak-smalltalk/squeak-app/pull/17#issuecomment-876753284. Sound is required for sonyx CD.